### PR TITLE
(GH-55) Allow creating screenshots when timed out.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ code_drop
 [Bb]in
 obj
 src/packages
+src/.vs
 
 
 *.suo

--- a/src/chocolatey.package.verifier.host/shell/PrepareMachine.ps1
+++ b/src/chocolatey.package.verifier.host/shell/PrepareMachine.ps1
@@ -24,6 +24,11 @@ try {
 Write-Output 'Setting Windows Update service to Manual startup type'
 Set-Service -Name wuauserv -StartupType Manual
 
+Write-Output 'Setting "Turn off display" to never on AC power'
+# this is required to keep the monitor on to create 
+# a screenshot that is not "black" when timed out.
+powercfg -change -monitor-timeout-ac 0
+
 $exitCode = 0
 
 & c:\vagrant\shell\InstallNet4.ps1

--- a/src/chocolatey.package.verifier/infrastructure.app/tasks/TestPackageTask.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/tasks/TestPackageTask.cs
@@ -121,7 +121,8 @@ namespace chocolatey.package.verifier.infrastructure.app.tasks
                         _configuration.CommandExecutionTimeoutSeconds),
                     () =>
                     {
-                        if (string.IsNullOrWhiteSpace(_vboxManageExe) || !string.IsNullOrWhiteSpace(_configuration.VboxIdPath)) return;
+                        this.Log().Info(() => "Timeout triggered.");
+                        if (string.IsNullOrWhiteSpace(_vboxManageExe) || string.IsNullOrWhiteSpace(_configuration.VboxIdPath)) return;
                         if (!_fileSystem.file_exists(_configuration.VboxIdPath)) return;
                         var vmId = _fileSystem.read_file(_configuration.VboxIdPath);
                         if (string.IsNullOrWhiteSpace(vmId)) return;


### PR DESCRIPTION
Relates to #55 

I have fixed an issue that would not allow screenshots to be taken.
Having screenshots allows us to be able to show what is going
on on the package-verifier when an timeout is triggered.
To achieve this, I have disabled the "Turn off the display" power setting.
I also added an informational log entry to show when a timeout is
triggered, allowing us to find the logs entries.

For an example output see: 
https://gist.github.com/mkevenaar-dev/bcf14c86c01bc641fb977a8f74eb667f#file-installimage-md

# Release notes:
* Create an ImUrl app https://api.imgur.com/oauth2/addclient of type "OAuth 2 authorization without a callback URL" if you don't already have done so.
* The current vagrant box should be destroyed so changes to the `PrepareMachine.ps1` will be implemented (Look for the line with `Setting "Turn off display" to never on AC power`)
* Make sure the following settings are correct in the `package-verifier.exe.config` file:
  * `<add key="PathToVirtualBox" value="C:\Program Files\Oracle\VirtualBox" />` 
Should be absolute path to the VirtualBox installation folder
  * `<add key="VboxIdPath" value=".\.vagrant\machines\default\virtualbox\id" />` 
Should be relative to the installation folder
  * `<add key="ImageUpload.ClientId" value="nope" />` 
Value should be from Imgur 
  * `<add key="ImageUpload.ClientSecret" value="nada" />` 
Value should be from Imgur
