### PR TITLE
(GH-55) Replace ImgUr with S3 bucket or local storage

### DIFF
--- a/src/chocolatey.package.verifier.host/app.config
+++ b/src/chocolatey.package.verifier.host/app.config
@@ -24,8 +24,19 @@
     <add key="GitHub.Token" value="nope" />
     <add key="GitHub.UserName" value="nobody" />
     <add key="GitHub.Password" value="ya" />
-    <add key="ImageUpload.ClientId" value="nada" />
-    <add key="ImageUpload.ClientSecret" value="nope" />
+
+    <!-- Screenshots start -->
+    <!-- common settings -->
+    <add key="ImagesStoreType" value="FileSystem"/>
+    <add key="ImagesUploadFolder" value="verifier-screenshots" />
+    <add key="ImagesUrl" value="https://chocolatey.org" />
+    <!-- AWS S3 bucket settings -->
+    <add key="S3Bucket" value="" />
+    <add key="S3AccessKey" value="" />
+    <add key="S3SecretKey" value="" />
+    <!-- local settings -->
+    <add key="ImagesFolder" value="..\Website" />
+    <!-- Screenshots end -->
   </appSettings>
   
   <system.net>

--- a/src/chocolatey.package.verifier.host/chocolatey.package.verifier.host.csproj
+++ b/src/chocolatey.package.verifier.host/chocolatey.package.verifier.host.csproj
@@ -80,8 +80,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Imgur.API, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Imgur.API.4.0.1\lib\net45\Imgur.API.dll</HintPath>
+    <Reference Include="AWSSDK, Version=1.3.18.0, Culture=neutral, PublicKeyToken=cd2d24cd2bace800, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\AWSSDK.1.3.18.0\lib\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
@@ -98,9 +99,6 @@
     <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SimpleInjector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.2.0.0\lib\net40-client\SimpleInjector.dll</HintPath>

--- a/src/chocolatey.package.verifier.host/package-verifier.exe.config.template
+++ b/src/chocolatey.package.verifier.host/package-verifier.exe.config.template
@@ -24,15 +24,26 @@
     <add key="GitHub.Token" value="${github.token}"/>
     <add key="GitHub.UserName" value="${github.username}"/>
     <add key="GitHub.Password" value="${github.password}"/>
-    <add key="ImageUpload.ClientId" value="" />
-    <add key="ImageUpload.ClientSecret" value="" />
+
+    <!-- Screenshots start -->
+    <!-- common settings -->
+    <add key="ImagesStoreType" value="FileSystem"/>
+    <add key="ImagesUploadFolder" value="verifier-screenshots" />
+    <add key="ImagesUrl" value="https://chocolatey.org" />
+    <!-- AWS S3 bucket settings -->
+    <add key="S3Bucket" value="" />
+    <add key="S3AccessKey" value="" />
+    <add key="S3SecretKey" value="" />
+    <!-- local settings -->
+    <add key="ImagesFolder" value="..\Website" />
+    <!-- Screenshots end -->
   </appSettings>
   
   <system.net>
     <mailSettings>
       <!-- Local Debug directory -->
       <smtp deliveryMethod="${server.smtp.deliveryMethod}" from="package-verifier-service@noreply.org">
-        <network host="${server.smtp}" defaultCredentials="${email.use.defaultCredentials}" enableSsl="${server.smtp.enablessl}" port="${server.smtp.port}" ${server.smtp.credentials} />
+        <network host="${server.smtp}" defaultCredentials="${email.use.defaultCredentials}" enableSsl="${server.smtp.enablessl}" port="${server.smtp.port}" server="${server.smtp.credentials}" />
         <specifiedPickupDirectory pickupDirectoryLocation=".\App_Data\Email"/>
       </smtp>
     </mailSettings>

--- a/src/chocolatey.package.verifier.host/packages.config
+++ b/src/chocolatey.package.verifier.host/packages.config
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Imgur.API" version="4.0.1" targetFramework="net452" />
+  <package id="AWSSDK" version="1.3.18.0" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="PublishedApplications" version="2.1.0.0" />
   <package id="SimpleInjector" version="2.0.0" targetFramework="net40" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net452" />

--- a/src/chocolatey.package.verifier.tests.integration/App.config
+++ b/src/chocolatey.package.verifier.tests.integration/App.config
@@ -7,12 +7,4 @@
     <add key="GitHub.UserName" value="" />
     <add key="GitHub.Password" value="" />
   </appSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/src/chocolatey.package.verifier.tests/App.config
+++ b/src/chocolatey.package.verifier.tests/App.config
@@ -18,10 +18,6 @@
         <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.30214.0" newVersion="2.1.30214.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/src/chocolatey.package.verifier/chocolatey.package.verifier.csproj
+++ b/src/chocolatey.package.verifier/chocolatey.package.verifier.csproj
@@ -36,11 +36,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AWSSDK, Version=1.3.18.0, Culture=neutral, PublicKeyToken=cd2d24cd2bace800, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\AWSSDK.1.3.18.0\lib\AWSSDK.dll</HintPath>
+    </Reference>
     <Reference Include="EnsureThat">
       <HintPath>..\packages\Ensure.That.0.5.0\lib\EnsureThat.dll</HintPath>
-    </Reference>
-    <Reference Include="Imgur.API, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Imgur.API.4.0.1\lib\net45\Imgur.API.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
@@ -65,9 +66,6 @@
     <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=1.6.30117.9648, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -127,6 +125,7 @@
     <Compile Include="EnumerationExtensions.cs" />
     <Compile Include="infrastructure.app\ApplicationFileType.cs" />
     <Compile Include="infrastructure.app\FileInformation.cs" />
+    <Compile Include="infrastructure.app\ImagesStoreType.cs" />
     <Compile Include="infrastructure.app\messaging\FinalPackageTestResultMessage.cs" />
     <Compile Include="infrastructure.app\messaging\ImportFilesCompleteMessage.cs" />
     <Compile Include="infrastructure.app\messaging\VerifyPackageMessage.cs" />
@@ -136,7 +135,12 @@
     <Compile Include="infrastructure.app\results\NuGetServiceGetClientResult.cs" />
     <Compile Include="infrastructure.app\results\PackageTestResult.cs" />
     <Compile Include="infrastructure.app\messaging\PackageTestResultMessage.cs" />
+    <Compile Include="infrastructure.app\services\AmazonS3ClientWrapper.cs" />
+    <Compile Include="infrastructure.app\services\AmazonS3FileStorageService.cs" />
+    <Compile Include="infrastructure.app\services\FileSystemFileStorageService.cs" />
     <Compile Include="infrastructure.app\services\GistService.cs" />
+    <Compile Include="infrastructure.app\services\IAmazonS3Client.cs" />
+    <Compile Include="infrastructure.app\services\IFileStorageService.cs" />
     <Compile Include="infrastructure.app\services\IGistService.cs" />
     <Compile Include="infrastructure.app\services\IImageUploadService.cs" />
     <Compile Include="infrastructure.app\services\ImageUploadService.cs" />

--- a/src/chocolatey.package.verifier/infrastructure.app/ImagesStoreType.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/ImagesStoreType.cs
@@ -1,0 +1,24 @@
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.package.verifier.infrastructure.app
+{
+    public enum ImagesStoreType
+    {
+        NotSpecified = 0,
+        FileSystem,
+        AmazonS3Storage
+    }
+}

--- a/src/chocolatey.package.verifier/infrastructure.app/configuration/ConfigurationSettings.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/configuration/ConfigurationSettings.cs
@@ -176,27 +176,45 @@ namespace chocolatey.package.verifier.infrastructure.app.configuration
         }
 
         /// <summary>
-        /// Gets the image upload client identifier.
+        /// Gets the S3 bucket name
         /// </summary>
-        /// <value>
-        /// The image upload client identifier.
-        /// </value>
-        public string ImageUploadClientId {
-            get
-            {
-                return get_application_settings_value("ImageUpload.ClientId");
-            }
-        }
+        public string S3Bucket { get { return get_application_settings_value("S3Bucket"); } }
+
         /// <summary>
-        /// Gets the image upload client secret.
+        /// Gets the friendly Images Url
         /// </summary>
-        /// <value>
-        /// The image upload client secret.
-        /// </value>
-        public string ImageUploadClientSecret {
+        public string ImagesUrl { get { return get_application_settings_value("ImagesUrl"); } }
+
+        /// <summary>
+        /// Gets the local images folder
+        /// </summary>
+        public string ImagesUploadFolder { get { return get_application_settings_value("ImagesUploadFolder"); } }
+
+        /// <summary>
+        /// Gets the remote folder
+        /// </summary>
+        public string ImagesFolder { get { return get_application_settings_value("ImagesFolder"); } }
+
+        /// <summary>
+        /// Gets the Amazon S3 access key
+        /// </summary>
+        public string S3AccessKey { get { return get_application_settings_value("S3AccessKey"); } }
+
+        /// <summary>
+        /// Gets the Amazon S3 Secret key
+        /// </summary>
+        public string S3SecretKey { get { return get_application_settings_value("S3SecretKey"); } }
+
+        /// <summary>
+        /// Gets the Image Store Type
+        /// </summary>
+        public ImagesStoreType ImagesStoreType
+        {
             get
             {
-                return get_application_settings_value("ImageUpload.ClientSecret");
+                var data = get_application_settings_value("ImagesStoreType");
+                var storeType = (ImagesStoreType)Enum.Parse(typeof(ImagesStoreType), data);
+                return Enum.IsDefined(typeof(ImagesStoreType), storeType) ? storeType : ImagesStoreType.NotSpecified;
             }
         }
     }

--- a/src/chocolatey.package.verifier/infrastructure.app/configuration/IConfigurationSettings.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/configuration/IConfigurationSettings.cs
@@ -113,21 +113,61 @@ namespace chocolatey.package.verifier.infrastructure.app.configuration
         /// The vbox identifier file path.
         /// </value>
         string VboxIdPath { get;}
-        
-        /// <summary>
-        /// Gets the image upload client identifier.
-        /// </summary>
-        /// <value>
-        /// The image upload client identifier.
-        /// </value>
-        string ImageUploadClientId { get; }
 
         /// <summary>
-        /// Gets the image upload client secret.
+        /// Gets the S3 Bucket name
         /// </summary>
         /// <value>
-        /// The image upload client secret.
+        /// The S3 Bucket name
         /// </value>
-        string ImageUploadClientSecret { get; }
+        string S3Bucket { get; }
+
+        /// <summary>
+        /// Gets the local folder where images will be stored.
+        /// </summary>
+        /// <value>
+        /// The local ImagesFolder directory name
+        /// </value>
+        string ImagesFolder { get; }
+
+        /// <summary>
+        /// Gets the folder where images will be uploaded.
+        /// </summary>
+        /// <value>
+        /// The ImagesUploadFolder directory name
+        /// </value>
+        string ImagesUploadFolder { get; }
+
+        /// <summary>
+        /// Gets the friendly URL for the images folder.
+        /// </summary>
+        /// <value>
+        /// The friendly URL to the images
+        /// </value>
+        string ImagesUrl { get; }
+
+        /// <summary>
+        /// Gets the S3 Access Key
+        /// </summary>
+        /// <value>
+        /// The Amazon S3 access key
+        /// </value>
+        string S3AccessKey { get; }
+
+        /// <summary>
+        /// Gets the S3 Secret Key
+        /// </summary>
+        /// <value>
+        /// The Amazon S3 secret key
+        /// </value>
+        string S3SecretKey { get; }
+
+        /// <summary>
+        /// Get the type of images store
+        /// </summary>
+        /// <value>
+        /// The Images Store type you want.
+        /// </value>
+        ImagesStoreType ImagesStoreType { get; }
     }
 }

--- a/src/chocolatey.package.verifier/infrastructure.app/registration/ContainerBinding.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/registration/ContainerBinding.cs
@@ -48,6 +48,18 @@ namespace chocolatey.package.verifier.infrastructure.app.registration
             container.Register<IMessageSubscriptionManagerService, MessageSubscriptionManagerService>(Lifestyle.Singleton);
             EventManager.initialize_with(container.GetInstance<IMessageSubscriptionManagerService>);
 
+            switch (configuration.ImagesStoreType)
+            {
+                case ImagesStoreType.AmazonS3Storage:
+                    container.Register<IAmazonS3Client, AmazonS3ClientWrapper>(Lifestyle.Singleton);
+                    container.Register<IFileStorageService, AmazonS3FileStorageService>(Lifestyle.Singleton);
+                    break;
+                case ImagesStoreType.FileSystem:
+                case ImagesStoreType.NotSpecified:
+                    container.Register<IFileStorageService, FileSystemFileStorageService>(Lifestyle.Singleton);
+                    break;
+            }
+
             container.Register<INotificationSendService, SmtpMarkdownNotificationSendService>(Lifestyle.Singleton);
             container.Register<IMessageService, MessageService>(Lifestyle.Singleton);
             container.Register<IEmailDistributionService, EmailDistributionService>(Lifestyle.Singleton);

--- a/src/chocolatey.package.verifier/infrastructure.app/services/AmazonS3ClientWrapper.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/services/AmazonS3ClientWrapper.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+// authors/contributors from ChocolateyGallery
+// at https://github.com/chocolatey/chocolatey.org,
+// and the authors/contributors of NuGetGallery 
+// at https://github.com/NuGet/NuGetGallery
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Amazon;
+using Amazon.S3;
+using chocolatey.package.verifier.infrastructure.app.configuration;
+
+namespace chocolatey.package.verifier.infrastructure.app.services
+{
+    public class AmazonS3ClientWrapper : IAmazonS3Client
+    {
+        private readonly IConfigurationSettings configuration;
+        private readonly string accessKeyId = "";
+        private readonly string accessSecret = "";
+
+        public AmazonS3ClientWrapper(IConfigurationSettings configuration)
+        {
+            this.configuration = configuration;
+            accessKeyId = configuration.S3AccessKey;
+            accessSecret = configuration.S3SecretKey;
+            BucketName = configuration.S3Bucket;
+            ImagesUrl = configuration.ImagesUrl;
+        }
+
+        public string BucketName { get; private set; }
+        public string ImagesUrl { get; private set; }
+
+        public AmazonS3 create_instance()
+        {
+            return AWSClientFactory.CreateAmazonS3Client(accessKeyId, accessSecret);
+        }
+    }
+}

--- a/src/chocolatey.package.verifier/infrastructure.app/services/AmazonS3FileStorageService.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/services/AmazonS3FileStorageService.cs
@@ -1,0 +1,178 @@
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+// authors/contributors from ChocolateyGallery
+// at https://github.com/chocolatey/chocolatey.org,
+// and the authors/contributors of NuGetGallery 
+// at https://github.com/NuGet/NuGetGallery
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace chocolatey.package.verifier.infrastructure.app.services
+{
+    public class AmazonS3FileStorageService : IFileStorageService
+    {
+        private readonly IAmazonS3Client clientContext;
+
+        public AmazonS3FileStorageService(IAmazonS3Client clientContext)
+        {
+            this.clientContext = clientContext;
+        }
+
+        private T wrap_request_in_error_handler<T>(Func<T> func)
+        {
+            try
+            {
+                return func.Invoke();
+            }
+            catch (AmazonS3Exception amazonS3Exception)
+            {
+                if (amazonS3Exception.ErrorCode != null
+                    && (
+                           amazonS3Exception.ErrorCode.Equals("InvalidAccessKeyId")
+                           || amazonS3Exception.ErrorCode.Equals("InvalidSecurity"))
+                    )
+                {
+                    throw new AmazonS3Exception(
+                        "Please check the provided AWS Credentials. If you haven't signed up for Amazon S3, please visit http://aws.amazon.com/s3",
+                        amazonS3Exception);
+                }
+
+                throw;
+            }
+        }
+
+        public void delete_file(string folderName, string fileName)
+        {
+            // It's allowed to have an empty folder name. 
+            // if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+
+            folderName = (string.IsNullOrEmpty(folderName) ? String.Empty : folderName.Substring(folderName.Length - 1, 1) == "/" ? folderName : folderName + "/");
+            fileName = string.Format("{0}{1}", folderName, fileName);
+
+            var request = new DeleteObjectRequest();
+            request.WithBucketName(clientContext.BucketName);
+            request.WithKey(fileName);
+
+            using (AmazonS3 client = clientContext.create_instance())
+            {
+                S3Response response = wrap_request_in_error_handler(() => client.DeleteObject(request));
+            }
+        }
+
+        public bool file_exists(string folderName, string fileName)
+        {
+            // It's allowed to have an empty folder name. 
+            // if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+
+            folderName = (string.IsNullOrEmpty(folderName) ? String.Empty : folderName.Substring(folderName.Length - 1, 1) == "/" ? folderName : folderName + "/");
+            fileName = string.Format("{0}{1}", folderName, fileName);
+
+            var request = new ListObjectsRequest();
+            request.WithBucketName(clientContext.BucketName);
+            request.WithPrefix(fileName);
+
+            using (AmazonS3 client = clientContext.create_instance())
+            {
+                ListObjectsResponse response = wrap_request_in_error_handler(() => client.ListObjects(request));
+                var count = response.S3Objects.Count;
+                if (count == 1) return true;
+            }
+
+            return false;
+        }
+
+        public Stream get_file(string folderName, string fileName, bool useCache)
+        {
+            // It's allowed to have an empty folder name. 
+            // if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+
+            folderName = (string.IsNullOrEmpty(folderName) ? String.Empty : folderName.Substring(folderName.Length - 1, 1) == "/" ? folderName : folderName + "/");
+            fileName = string.Format("{0}{1}", folderName, fileName);
+
+            if (useCache && !string.IsNullOrWhiteSpace(clientContext.ImagesUrl))
+            {
+                var url = new Uri(string.Format("{0}/{1}", clientContext.ImagesUrl, fileName));
+                WebRequest request = WebRequest.Create(url);
+                WebResponse response = request.GetResponse();
+
+                return response.GetResponseStream();
+            }
+            else
+            {
+                var request = new GetObjectRequest();
+                request.WithBucketName(clientContext.BucketName);
+                request.WithKey(fileName);
+                request.WithTimeout((int)TimeSpan.FromMinutes(30).TotalMilliseconds);
+
+                using (AmazonS3 client = clientContext.create_instance())
+                {
+                    try
+                    {
+                        S3Response response = wrap_request_in_error_handler(() => client.GetObject(request));
+
+                        if (response != null) return response.ResponseStream;
+                    }
+                    catch (Exception)
+                    {
+                        //hate swallowing an error
+                    }
+
+                    return null;
+                }
+            }
+        }
+
+        public void save_file(string folderName, string fileName, Stream fileStream)
+        {
+            // It's allowed to have an empty folder name. 
+            // if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+            if (fileStream == null) throw new ArgumentNullException("fileStream");
+
+            folderName = (string.IsNullOrEmpty(folderName) ? String.Empty : folderName.Substring(folderName.Length - 1, 1) == "/" ? folderName : folderName + "/");
+            fileName = string.Format("{0}{1}", folderName, fileName);
+
+            var request = new PutObjectRequest();
+            request.WithBucketName(clientContext.BucketName);
+            request.WithKey(fileName);
+            request.WithInputStream(fileStream);
+            request.AutoCloseStream = true;
+            request.CannedACL = S3CannedACL.PublicRead;
+            request.WithTimeout((int)TimeSpan.FromMinutes(30).TotalMilliseconds);
+
+            using (AmazonS3 client = clientContext.create_instance())
+            {
+                S3Response response = wrap_request_in_error_handler(() => client.PutObject(request));
+            }
+        }
+
+        public string get_url(string folderName, string fileName)
+        {
+            folderName = (string.IsNullOrEmpty(folderName) ? String.Empty : folderName.Substring(folderName.Length-1,1) == "/" ? folderName : folderName + "/");
+
+            if (!string.IsNullOrWhiteSpace(clientContext.ImagesUrl))
+            {
+                return string.Format("{0}/{1}{2}", clientContext.ImagesUrl, folderName, fileName);
+            }
+            return string.Format("https://{0}.s3.amazonaws.com/{1}{2}", clientContext.BucketName, folderName, fileName);
+        }
+    }
+}

--- a/src/chocolatey.package.verifier/infrastructure.app/services/FileSystemFileStorageService.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/services/FileSystemFileStorageService.cs
@@ -1,0 +1,107 @@
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+// authors/contributors from ChocolateyGallery
+// at https://github.com/chocolatey/chocolatey.org,
+// and the authors/contributors of NuGetGallery 
+// at https://github.com/NuGet/NuGetGallery
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using System.IO;
+using chocolatey.package.verifier.infrastructure.app.configuration;
+using chocolatey.package.verifier.infrastructure.filesystem;
+
+namespace chocolatey.package.verifier.infrastructure.app.services
+{
+    public class FileSystemFileStorageService : IFileStorageService
+    {
+        private readonly IConfigurationSettings configuration;
+        private readonly IFileSystem fileSystemSvc;
+
+        public FileSystemFileStorageService(IConfigurationSettings configuration, IFileSystem fileSystemSvc)
+        {
+            this.configuration = configuration;
+            this.fileSystemSvc = fileSystemSvc;
+        }
+
+        private static string build_path(string imagesFolder, string folderName, string fileName)
+        {
+            return Path.Combine(imagesFolder, folderName, fileName);
+        }
+
+        public void delete_file(string folderName, string fileName)
+        {
+            if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+
+            var path = build_path(configuration.ImagesFolder, folderName, fileName);
+            if (fileSystemSvc.file_exists(path)) fileSystemSvc.delete_file(path);
+        }
+
+        public bool file_exists(string folderName, string fileName)
+        {
+            if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+
+            var path = build_path(configuration.ImagesFolder, folderName, fileName);
+            return fileSystemSvc.file_exists(path);
+        }
+
+        public Stream get_file(string folderName, string fileName)
+        {
+            if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+
+            var path = build_path(configuration.ImagesFolder, folderName, fileName);
+            if (fileSystemSvc.file_exists(path)) return fileSystemSvc.open_file_readonly(path);
+            else return null;
+        }
+
+        public Stream get_file(string folderName, string fileName, bool useCache)
+        {
+            return get_file(folderName, fileName);
+        }
+
+        public void save_file(string folderName, string fileName, Stream fileStream)
+        {
+            if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+            if (fileStream == null) throw new ArgumentNullException("fileStream");
+
+            if (!fileSystemSvc.directory_exists(configuration.ImagesFolder)) fileSystemSvc.create_directory(configuration.ImagesFolder);
+
+            var folderPath = Path.Combine(configuration.ImagesFolder, folderName);
+            if (!fileSystemSvc.directory_exists(folderPath)) fileSystemSvc.create_directory(folderPath);
+
+            var filePath = build_path(configuration.ImagesFolder, folderName, fileName);
+            if (fileSystemSvc.file_exists(filePath)) fileSystemSvc.delete_file(filePath);
+
+            fileSystemSvc.write_file(filePath, () => fileStream);
+        }
+
+        public string get_url(string folderName, string fileName)
+        {
+            if (String.IsNullOrWhiteSpace(folderName)) throw new ArgumentNullException("folderName");
+            if (String.IsNullOrWhiteSpace(fileName)) throw new ArgumentNullException("fileName");
+
+            folderName = (string.IsNullOrEmpty(folderName) ? String.Empty : folderName.Substring(folderName.Length - 1, 1) == "/" ? folderName : folderName + "/");
+            if (!string.IsNullOrWhiteSpace(configuration.ImagesUrl))
+            {
+                return string.Format("{0}/{1}{2}", configuration.ImagesUrl, folderName, fileName);
+            }
+
+            return "";
+        }
+    }
+}

--- a/src/chocolatey.package.verifier/infrastructure.app/services/IAmazonS3Client.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/services/IAmazonS3Client.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+// authors/contributors from ChocolateyGallery
+// at https://github.com/chocolatey/chocolatey.org,
+// and the authors/contributors of NuGetGallery 
+// at https://github.com/NuGet/NuGetGallery
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Amazon.S3;
+
+namespace chocolatey.package.verifier.infrastructure.app.services
+{
+    public interface IAmazonS3Client
+    {
+        string BucketName { get; }
+        string ImagesUrl { get; }
+        AmazonS3 create_instance();
+    }
+}

--- a/src/chocolatey.package.verifier/infrastructure.app/services/IFileStorageService.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/services/IFileStorageService.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+// authors/contributors from ChocolateyGallery
+// at https://github.com/chocolatey/chocolatey.org,
+// and the authors/contributors of NuGetGallery 
+// at https://github.com/NuGet/NuGetGallery
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+
+namespace chocolatey.package.verifier.infrastructure.app.services
+{
+    public interface IFileStorageService
+    {
+        void delete_file(string folderName, string fileName);
+
+        bool file_exists(string folderName, string fileName);      
+        
+        Stream get_file(string folderName, string fileName, bool useCache);
+
+        void save_file(string folderName, string fileName, Stream fileStream);
+
+        string get_url(string folderName, string fileName);
+    }
+}

--- a/src/chocolatey.package.verifier/packages.config
+++ b/src/chocolatey.package.verifier/packages.config
@@ -1,14 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AWSSDK" version="1.3.18.0" />
   <package id="Ensure.That" version="0.5.0" />
-  <package id="Imgur.API" version="4.0.1" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="MarkdownMailer" version="1.2.1.0" targetFramework="net452" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="Octokit" version="0.29.0" targetFramework="net452" />
   <package id="Reactive.EventAggregator" version="2.0.0" targetFramework="net452" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />


### PR DESCRIPTION
Relates to #55 
Fixes #73 

As discussed in https://github.com/chocolatey/package-verifier/issues/55#issuecomment-486727364 we need to replace ImgUr with an S3 bucket or local storage.

S3 option:
https://gist.github.com/mkevenaar-dev/2c2e67276c1f4fd29fb2f87353c4f0a3#file-installimage-md

Local storage:
https://gist.github.com/mkevenaar-dev/e73b872e5e580a93e351196fed6083d7#file-installimage-md
**NOTE:** The Image URL is not externally accessible, and therefor not shown

Use the `RAW` button to view the URL.