### PR TITLE
(GH-80) Set TLS 1.2 protocol

### DIFF
--- a/src/chocolatey.package.verifier.host/shell/InstallChocolatey.ps1
+++ b/src/chocolatey.package.verifier.host/shell/InstallChocolatey.ps1
@@ -9,6 +9,20 @@ $env:Path += ";$ChocoInstallPath"
 $DebugPreference = "Continue";
 $env:ChocolateyEnvironmentDebug = 'true'
 
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+try {
+  # Set TLS 1.2 (3072) as that is the minimum required by Chocolatey.org.
+  # Use integers because the enumeration value for TLS 1.2 won't exist
+  # in .NET 4.0, even though they are addressable if .NET 4.5+ is
+  # installed (.NET 4.5 is an in-place upgrade).
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+} catch {
+  Write-Output 'Unable to set PowerShell to use TLS 1.2. This is required for contacting Chocolatey as of 03 FEB 2020. https://chocolatey.org/blog/remove-support-for-old-tls-versions. If you see underlying connection closed or trust errors, you may need to do one or more of the following: (1) upgrade to .NET Framework 4.5+ and PowerShell v3+, (2) Call [System.Net.ServicePointManager]::SecurityProtocol = 3072; in PowerShell prior to attempting installation, (3) specify internal Chocolatey package location (set $env:chocolateyDownloadUrl prior to install or host the package internally), (4) use the Download + PowerShell method of install. See https://chocolatey.org/docs/installation for all install options.'
+}
+
 function Install-LocalChocolateyPackage {
 param (
   [string]$chocolateyPackageFilePath = ''


### PR DESCRIPTION
Sets the TLS 1.2 protocol to allow downloading Chocolatey from the website using the install script and other communication with Chocolatey.org.

This has been confirmed as working on the Package Verifier.

Code was taken from a [recent commit to chocolatey/chocolatey.org](https://github.com/chocolatey/chocolatey.org/commit/cf136694755899e3aee2dcb7c77d8c7448f97eaa#diff-728bffad54ac7ead7f6bb3adef3e6abdR63-R76)