### PR TITLE
(GH-86) Add check of PackageValidationResultStatus 

### DIFF
--- a/src/chocolatey.package.verifier.host/infrastructure/registration/ContainerBindingConsole.cs
+++ b/src/chocolatey.package.verifier.host/infrastructure/registration/ContainerBindingConsole.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright © 2015 - Present RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/chocolatey.package.verifier.host/infrastructure/registration/ContainerBindingConsole.cs
+++ b/src/chocolatey.package.verifier.host/infrastructure/registration/ContainerBindingConsole.cs
@@ -60,10 +60,13 @@ namespace chocolatey.package.verifier.host.infrastructure.registration
             }
             else
             {
+                // We should only include packages in the verification queue, if they have first been successfully validated, or if it has been
+                // exempted from validation.
                 packagesCheckTask.AdditionalPackageSelectionFilters = p => p.Where(
-                    pv => (pv.PackageTestResultStatus == null 
-                           || pv.PackageTestResultStatus == "Pending" 
-                           || pv.PackageTestResultStatus == "Unknown")
+                    pv => (pv.PackageTestResultStatus == null
+                           || pv.PackageTestResultStatus == "Pending"
+                           || pv.PackageTestResultStatus == "Unknown") &&
+                          (pv.PackageValidationResultStatus == "Passing" || pv.PackageValidationResultStatus == "Exempted")
                           );
             }
 


### PR DESCRIPTION
In order to be added to the package-verifier queue, a package must first
have a PackageValidationResultStatus set.  This needs to either be
"Passing", meaning that it successfully went through package-validator,
or "Exempted" meaning that it was manually exempted from the
package-validator checks.

Fixes #86 