### PR TITLE
(#90) Update shell scripts

### DIFF
--- a/src/chocolatey.package.verifier.host/shell/ChocolateyAction.ps1
+++ b/src/chocolatey.package.verifier.host/shell/ChocolateyAction.ps1
@@ -2,6 +2,20 @@ $env:PATH +=";$($env:SystemDrive)\ProgramData\chocolatey\bin"
 # https://github.com/chocolatey/choco/issues/512
 $validExitCodes = @(0, 1605, 1614, 1641, 3010)
 
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+try {
+  # Set TLS 1.2 (3072) as that is the minimum required by Chocolatey.org.
+  # Use integers because the enumeration value for TLS 1.2 won't exist
+  # in .NET 4.0, even though they are addressable if .NET 4.5+ is
+  # installed (.NET 4.5 is an in-place upgrade).
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+} catch {
+  Write-Output 'Unable to set PowerShell to use TLS 1.2. This is required for contacting Chocolatey as of 03 FEB 2020. https://chocolatey.org/blog/remove-support-for-old-tls-versions. If you see underlying connection closed or trust errors, you may need to do one or more of the following: (1) upgrade to .NET Framework 4.5+ and PowerShell v3+, (2) Call [System.Net.ServicePointManager]::SecurityProtocol = 3072; in PowerShell prior to attempting installation, (3) specify internal Chocolatey package location (set $env:chocolateyDownloadUrl prior to install or host the package internally), (4) use the Download + PowerShell method of install. See https://chocolatey.org/docs/installation for all install options.'
+}
+
 [[Command]]
 
 $exitCode = $LASTEXITCODE

--- a/src/chocolatey.package.verifier.host/shell/InstallChocolatey.ps1
+++ b/src/chocolatey.package.verifier.host/shell/InstallChocolatey.ps1
@@ -36,7 +36,7 @@ param (
     throw "No file exists at $chocolateyPackageFilePath"
   }
 
-  if ($env:TEMP -eq $null) {
+  if ($null -eq $env:TEMP) {
     $env:TEMP = Join-Path $env:SystemDrive 'temp'
   }
   $chocTempDir = Join-Path $env:TEMP "chocolatey"
@@ -93,5 +93,13 @@ choco feature enable -n allowGlobalConfirmation
 choco feature enable -n logEnvironmentValues
 choco feature disable -n showDownloadProgress
 #choco feature disable -n powershellHost
+
+$cachedPackagesPath = 'c:\cached-packages'
+if (Test-Path -Path $cachedPackagesPath -PathType Container) {
+  Write-Output "Local packages path '$cachedPackagesPath' exists. Adding as a Chocolatey source with priority 1."
+  choco source add --name="'cached-packages'" --source="'$cachedPackagesPath'" --priority=1
+} else {
+  Write-Output "Local packages path '$cachedPackagesPath' does not exist. All packages will be downloaded from Chocolatey.org"
+}
 
 Exit $LASTEXITCODE

--- a/src/chocolatey.package.verifier.host/shell/PrepareMachine.ps1
+++ b/src/chocolatey.package.verifier.host/shell/PrepareMachine.ps1
@@ -45,4 +45,7 @@ if ($scriptExitCode -ne 0 -and $scriptExitCode -ne '') {
 
 & c:\vagrant\shell\NotifyGuiAppsOfEnvironmentChanges.ps1
 
+# install the latest version of the virtual box guest extensions
+choco install virtualbox-guest-additions-guest.install
+
 Exit $exitCode


### PR DESCRIPTION
The shell scripts have been updated to make them more efficient when verifying packages. The changes are:

* Using a local packages cache;
*  Setting TLS 1.2 for belt and braces;
* Installing the latest VirtualBox Guest additions in the Vagrant virtual machine;