### PR TITLE
(GH-89) (GH-94) Change how packages are brought into queue

### DIFF
--- a/src/chocolatey.package.verifier.host/infrastructure/registration/ContainerBindingConsole.cs
+++ b/src/chocolatey.package.verifier.host/infrastructure/registration/ContainerBindingConsole.cs
@@ -62,12 +62,12 @@ namespace chocolatey.package.verifier.host.infrastructure.registration
             {
                 // We should only include packages in the verification queue, if they have first been successfully validated, or if it has been
                 // exempted from validation.
+                // In the case where the package version is a pre-release package, if it has also failed validation, it should be added to the
+                // package verifier queue
                 packagesCheckTask.AdditionalPackageSelectionFilters = p => p.Where(
-                    pv => (pv.PackageTestResultStatus == null
-                           || pv.PackageTestResultStatus == "Pending"
-                           || pv.PackageTestResultStatus == "Unknown") &&
-                          (pv.PackageValidationResultStatus == "Passing" || pv.PackageValidationResultStatus == "Exempted")
-                          );
+                    pv => (pv.PackageTestResultStatus == null || pv.PackageTestResultStatus == "Pending" || pv.PackageTestResultStatus == "Unknown") &&
+                          ((pv.PackageValidationResultStatus == "Passing" || pv.PackageValidationResultStatus == "Exempted") ||
+                          (pv.IsPrerelease && pv.PackageValidationResultStatus == "Failing")));
             }
 
             container.Register<IEnumerable<ITask>>(

--- a/src/chocolatey.package.verifier/infrastructure.app/tasks/CheckForPackagesTask.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/tasks/CheckForPackagesTask.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright © 2015 - Present RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/chocolatey.package.verifier/infrastructure.app/tasks/CheckForPackagesTask.cs
+++ b/src/chocolatey.package.verifier/infrastructure.app/tasks/CheckForPackagesTask.cs
@@ -85,10 +85,8 @@ namespace chocolatey.package.verifier.infrastructure.app.tasks
                     Timeout = 70
                 };
 
-                var cacheTimeout = DateTime.UtcNow.AddMinutes(-31);
                 // this only returns 40 results at a time but at least we'll have something to start with
-                IQueryable<V2FeedPackage> packageQuery =
-                    service.Packages.Where(p => p.Created < cacheTimeout);
+                IQueryable<V2FeedPackage> packageQuery = service.Packages;
 
                 if (AdditionalPackageSelectionFilters != null) packageQuery = AdditionalPackageSelectionFilters.Invoke(packageQuery);
 


### PR DESCRIPTION
Previously, both package-validator and package-verifier would wait a set
period of time after a package was pushed to bring them into the queue.
This prevented caching problems from happening. This is no longer
required for the package-verifier, since packages won't come into the
package-verifier queue until they have gone through the package-validator
queue, which will still wait for the cache timeout period.

There are times when a pre-release package will "fail" package
validator, but we want testing to still progress to the package
verifier.  In the case where a package has failed validator _and_ is
a pre-release package, include it in the package verifier queue.

Fixes #89 and #94 