### PR TITLE
(GH-100) Fix Choco package source folder copy criteria

### DIFF
--- a/nuget/tools/chocolateyInstall.ps1
+++ b/nuget/tools/chocolateyInstall.ps1
@@ -56,7 +56,7 @@ if (-not (Test-Path -Path $configPath)) {
 
 $sourcePath = (Join-Path -Path $toolsDir -ChildPath "files")
 Write-Verbose "Copying files from '$sourcePath' to '$destinationPath'"
-Copy-Item -Path $sourcePath -Destination $destinationPath -Recurse -Force
+Copy-Item -Path "$sourcePath\*" -Destination $destinationPath -Recurse -Force
 
 Write-Verbose "Removing package files from '$sourcePath'"
 Remove-Item -Path $sourcePath -Recurse -Force


### PR DESCRIPTION
Changes the copy path to copy _from_ the `files` folder to the root of the destination.

Fixes #100 